### PR TITLE
receipt-api/9 add frontend error handling

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { MatIconModule } from "@angular/material/icon"
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 // Project component imports
 import { AppRoutingModule } from './app-routing/index';
@@ -42,6 +43,7 @@ import { ReceiptItemComponent } from './components/receipt-item/receipt-item.com
     MatButtonModule,
     HttpClientModule,
     MatDividerModule,
+    MatSnackBarModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -17,18 +17,18 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 // Project component imports
 import { AppRoutingModule } from './app-routing/index';
 import { AppComponent } from './app.component';
-import { 
-  ReceiptFormComponent,
-} from './components/index';
+import { ReceiptFormComponent } from './components/index';
 import { ReceiptItemListComponent } from './components/receipt-item-list/receipt-item-list.component';
 import { ReceiptItemComponent } from './components/receipt-item/receipt-item.component';
+import { NotificationSnackbarComponent } from './components/notification-snackbar/notification-snackbar.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     ReceiptFormComponent,
     ReceiptItemListComponent,
-    ReceiptItemComponent
+    ReceiptItemComponent,
+    NotificationSnackbarComponent
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/components/index.ts
+++ b/frontend/src/app/components/index.ts
@@ -1,7 +1,11 @@
 import { ReceiptFormComponent } from "./receipt-form/receipt-form.component";
 import { ReceiptItemListComponent } from "./receipt-item-list/receipt-item-list.component";
+import { ReceiptItemComponent } from "./receipt-item/receipt-item.component";
+import { NotificationSnackbarComponent } from "./notification-snackbar/notification-snackbar.component";
 
 export {
+  NotificationSnackbarComponent,
   ReceiptFormComponent,
+  ReceiptItemComponent,
   ReceiptItemListComponent,
 };

--- a/frontend/src/app/components/notification-snackbar/notification-snackbar.component.css
+++ b/frontend/src/app/components/notification-snackbar/notification-snackbar.component.css
@@ -46,7 +46,3 @@
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
 }
-
-button:hover mat-icon-button:hover {
-  background-color: rgb(253, 237, 237);
-}

--- a/frontend/src/app/components/notification-snackbar/notification-snackbar.component.css
+++ b/frontend/src/app/components/notification-snackbar/notification-snackbar.component.css
@@ -1,0 +1,52 @@
+:host { display: flex; }
+
+.snackbar-error {
+  font-weight: lighter;
+
+  /* light from inspecting mui element */
+  color: rgb(95, 33, 32);
+  background-color: rgb(253, 237, 237);
+
+  /* light */
+  /* background-color: #ef5350; */
+
+  /* main */
+  /* background-color: #d32f2f;  */
+
+  /* dark */
+  /* background-color: #c62828; */
+}
+
+.snackbar-success {
+  font-weight: lighter;
+
+  /* light from inspecting mui element */
+  color: rgb(30, 70, 32);
+  background-color: rgb(237, 247, 237);
+
+  /* light */
+  /* background-color: #4caf50; */
+
+  /* main */
+  /* background-color: #2e7d32;  */
+
+  /* dark */
+  /* background-color: #1b5e20; */
+}
+
+.text-radius {
+  text-align: center;
+  margin-left: -1.5rem; /* this is to compensate for the negative margin towards the right of the snackbar */
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.button-radius {
+  margin-right: -2rem; /* this is hacky, there's extra room to the right of the button for some reason */
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+button:hover mat-icon-button:hover {
+  background-color: rgb(253, 237, 237);
+}

--- a/frontend/src/app/components/notification-snackbar/notification-snackbar.component.html
+++ b/frontend/src/app/components/notification-snackbar/notification-snackbar.component.html
@@ -1,0 +1,12 @@
+<span class="{{ snackBarData.severity }} text-radius" matSnackBarLabel>
+  {{ snackBarData.message }}
+</span>
+
+<span class="{{ snackBarData.severity }} button-radius" matSnackBarActions>
+  <button
+    mat-icon-button
+    (click)="snackBarRef.dismissWithAction()"
+  >
+    <mat-icon>delete</mat-icon>
+  </button>
+</span>

--- a/frontend/src/app/components/notification-snackbar/notification-snackbar.component.ts
+++ b/frontend/src/app/components/notification-snackbar/notification-snackbar.component.ts
@@ -1,0 +1,16 @@
+import { Component, Inject, inject } from '@angular/core';
+import { MatSnackBarRef, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { SnackbarData } from "../../model";
+
+@Component({
+  selector: 'app-notification-snackbar',
+  templateUrl: './notification-snackbar.component.html',
+  styleUrls: ['./notification-snackbar.component.css']
+})
+export class NotificationSnackbarComponent {
+  public snackBarRef = inject(MatSnackBarRef);
+
+  public constructor(
+    @Inject(MAT_SNACK_BAR_DATA) public snackBarData: SnackbarData
+  ) { }
+}

--- a/frontend/src/app/components/receipt-form/receipt-form.component.css
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.css
@@ -22,3 +22,8 @@ button {
   width: 22rem;
   margin-left: 0.65rem;
 }
+
+::ng-deep .snackbar-warning {
+  color: black !important;
+  background-color: red !important;
+}

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -46,7 +46,7 @@ export class ReceiptFormComponent {
       this.receiptApiService.processReceipt(possibleReceipt).subscribe(
         (receiptId) => {
           console.log(`\nReceiptIdResponse:\n${JSON.stringify(receiptId)}\n`);
-          this.notificationService.setNotification(this.notificationSnackBar, ReceiptSuccess.ReceiptSubmission, SnackbarSeverity.Sucess);
+          this.notificationService.setNotification(this.notificationSnackBar, ReceiptSuccess.ReceiptSubmission, SnackbarSeverity.Success);
         },
         (err) => {
           console.error(`Error posting receipt object -- ${err}`);

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { Receipt, ReceiptItem } from 'src/app/model';
+import { ReceiptError, Receipt, ReceiptItem } from 'src/app/model';
 import { NotificationService, ReceiptApiService } from "../../services";
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -44,7 +44,7 @@ export class ReceiptFormComponent {
         },
         (err) => {
           console.error(`Error posting receipt object -- ${err}`);
-          this.notificationService.setNotification(this.notificationSnackBar, "There was an error submitting the receipt");
+          this.notificationService.setNotification(this.notificationSnackBar, ReceiptError.ReceiptSubmissionError);
         }
       );
     } catch(e: any) {
@@ -55,25 +55,21 @@ export class ReceiptFormComponent {
   private isFormValid(): Receipt {
     const retailer = this.receiptForm.value.retailerName;
     if (!retailer) {
-      console.warn("Retailer name is missing from form");
-      throw new Error("Retailer name is missing from the form");
+      throw new Error(ReceiptError.MissingRetailer);
     }
 
     const purchaseDate = this.receiptForm.value.purchaseDate;
     if (!purchaseDate) {
-      console.warn("Purchase date is missing from form");
-      throw new Error("Purchase date is missing from the form");
+      throw new Error(ReceiptError.MissingPurchaseDate);
     }
 
     const purchaseTime = this.receiptForm.value.purchaseTime;
     if (!purchaseTime) {
-      console.warn("Purchase time is missing from the form");
-      throw new Error("Purchase time is missing from the form");
+      throw new Error(ReceiptError.MissingPurchaseTime);
     }
 
     if (!this.receiptItems.length) {
-      console.warn("No items have been added to the receipt");
-      throw new Error("No items have been added to the receipt");
+      throw new Error(ReceiptError.MissingReceiptItems);
     }
 
     const receipt: Receipt = {

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -1,13 +1,19 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { ReceiptError, Receipt, ReceiptItem } from 'src/app/model';
+import {
+  ReceiptError,
+  ReceiptSuccess,
+  Receipt,
+  ReceiptItem,
+  SnackbarSeverity
+} from 'src/app/model';
 import { NotificationService, ReceiptApiService } from "../../services";
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-receipt-form',
   templateUrl: './receipt-form.component.html',
-  styleUrls: ['./receipt-form.component.css']
+  styleUrls: ['./receipt-form.component.css'],
 })
 export class ReceiptFormComponent {
 
@@ -40,7 +46,7 @@ export class ReceiptFormComponent {
       this.receiptApiService.processReceipt(possibleReceipt).subscribe(
         (receiptId) => {
           console.log(`\nReceiptIdResponse:\n${JSON.stringify(receiptId)}\n`);
-          this.notificationService.setNotification(this.notificationSnackBar, "Successfully submitted your receipt!");
+          this.notificationService.setNotification(this.notificationSnackBar, ReceiptSuccess.ReceiptSubmission, SnackbarSeverity.Sucess);
         },
         (err) => {
           console.error(`Error posting receipt object -- ${err}`);

--- a/frontend/src/app/components/receipt-item/receipt-item.component.ts
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.ts
@@ -4,7 +4,9 @@ import {
   Input,
   Output 
 } from '@angular/core';
-import { ReceiptItem } from 'src/app/model';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ReceiptError, ReceiptItem } from 'src/app/model';
+import { NotificationService } from 'src/app/services';
 
 @Component({
   selector: 'app-receipt-item',
@@ -12,6 +14,11 @@ import { ReceiptItem } from 'src/app/model';
   styleUrls: ['./receipt-item.component.css']
 })
 export class ReceiptItemComponent {
+
+  public constructor(
+    private notificationService: NotificationService,
+    private notificationSnackBar: MatSnackBar,
+  ) { }
 
   // this is used for displaying an already added ReceiptItem
   @Input() 
@@ -23,10 +30,16 @@ export class ReceiptItemComponent {
   public receiptItemEmitter = new EventEmitter<ReceiptItem>();
 
   public addReceiptItem(shortDescription: string, price: string): void {
-    // emites the newly created ReceiptItem to the parent component "ReceiptItemList"
-    this.receiptItemEmitter.emit({
-      shortDescription: shortDescription,
-      price: price
-    });
+    if (!shortDescription) {
+      this.notificationService.setNotification(this.notificationSnackBar, ReceiptError.MissingItemDescription);
+    } else if (!price) {
+      this.notificationService.setNotification(this.notificationSnackBar, ReceiptError.MissingItemPrice);
+    } else {
+      // emites the newly created ReceiptItem to the parent component "ReceiptItemList"
+      this.receiptItemEmitter.emit({
+        shortDescription: shortDescription,
+        price: price
+      });
+    }
   }
 }

--- a/frontend/src/app/model/index.ts
+++ b/frontend/src/app/model/index.ts
@@ -1,15 +1,23 @@
-import Receipt from "./receipt";
 import {
-  ReceiptError,
+  Receipt,
   ReceiptIdResponse,
   ReceiptItem,
   ReceiptPointsResponse,
 } from "./receipt";
+import {
+  ReceiptError,
+  ReceiptSuccess,
+  SnackbarData,
+  SnackbarSeverity
+} from "./snackbar-data"
 
 export {
   Receipt,
   ReceiptError,
+  ReceiptSuccess,
   ReceiptIdResponse,
   ReceiptItem,
   ReceiptPointsResponse,
+  SnackbarData,
+  SnackbarSeverity,
 };

--- a/frontend/src/app/model/index.ts
+++ b/frontend/src/app/model/index.ts
@@ -1,13 +1,15 @@
 import Receipt from "./receipt";
 import {
-  ReceiptItem,
+  ReceiptError,
   ReceiptIdResponse,
+  ReceiptItem,
   ReceiptPointsResponse,
 } from "./receipt";
 
 export {
   Receipt,
+  ReceiptError,
   ReceiptIdResponse,
-  ReceiptPointsResponse,
   ReceiptItem,
+  ReceiptPointsResponse,
 };

--- a/frontend/src/app/model/receipt.ts
+++ b/frontend/src/app/model/receipt.ts
@@ -1,12 +1,12 @@
-export type ReceiptPointsResponse = {
+type ReceiptPointsResponse = {
   points: string;
 };
 
-export type ReceiptIdResponse = {
+type ReceiptIdResponse = {
   id: string;
 };
 
-export type ReceiptItem = {
+type ReceiptItem = {
   shortDescription: string;
   price: string;
 };
@@ -19,15 +19,9 @@ type Receipt = {
   total: string;
 };
 
-// source of truth for error strings used through the project
-export enum ReceiptError {
-  MissingRetailer = "Retailer name is missing from the form",
-  MissingPurchaseDate = "Purchase date is missing from the form",
-  MissingPurchaseTime = "Purchase time is missing from the form",
-  MissingReceiptItems = "No items have been added to the receipt",
-  MissingItemDescription = "Please enter a short description of the receipt item",
-  MissingItemPrice = "Please enter a price for the receipt item",
-  ReceiptSubmissionError = "There was an error submitting the receipt",
+export {
+  Receipt,
+  ReceiptItem,
+  ReceiptIdResponse,
+  ReceiptPointsResponse,
 };
-
-export default Receipt;

--- a/frontend/src/app/model/receipt.ts
+++ b/frontend/src/app/model/receipt.ts
@@ -19,4 +19,15 @@ type Receipt = {
   total: string;
 };
 
+// source of truth for error strings used through the project
+export enum ReceiptError {
+  MissingRetailer = "Retailer name is missing from the form",
+  MissingPurchaseDate = "Purchase date is missing from the form",
+  MissingPurchaseTime = "Purchase time is missing from the form",
+  MissingReceiptItems = "No items have been added to the receipt",
+  MissingItemDescription = "Please enter a short description of the receipt item",
+  MissingItemPrice = "Please enter a price for the receipt item",
+  ReceiptSubmissionError = "There was an error submitting the receipt",
+};
+
 export default Receipt;

--- a/frontend/src/app/model/snackbar-data.ts
+++ b/frontend/src/app/model/snackbar-data.ts
@@ -4,7 +4,7 @@ type SnackbarData = {
 };
 
 enum SnackbarSeverity {
-  Sucess = "snackbar-success",
+  Success = "snackbar-success",
   Error = "snackbar-error"
 };
 

--- a/frontend/src/app/model/snackbar-data.ts
+++ b/frontend/src/app/model/snackbar-data.ts
@@ -1,0 +1,32 @@
+type SnackbarData = {
+  message: string;
+  severity: SnackbarSeverity;
+};
+
+enum SnackbarSeverity {
+  Sucess = "snackbar-success",
+  Error = "snackbar-error"
+};
+
+enum ReceiptError {
+  MissingRetailer = "Retailer name is missing from the form",
+  MissingPurchaseDate = "Purchase date is missing from the form",
+  MissingPurchaseTime = "Purchase time is missing from the form",
+  MissingReceiptItems = "No items have been added to the receipt",
+  MissingItemDescription = "Please enter a short description of the receipt item",
+  MissingItemPrice = "Please enter a price for the receipt item",
+  ReceiptSubmissionError = "There was an error submitting the receipt",
+  // NOTE: when adding new possible error messages for the MatSnackBar add them here
+};
+
+enum ReceiptSuccess {
+  ReceiptSubmission = "Successfully submitted your receipt!",
+  // NOTE: when adding new possible success messages for the MatSnackBar add them here
+};
+
+export {
+  ReceiptError,
+  ReceiptSuccess,
+  SnackbarData,
+  SnackbarSeverity,
+};

--- a/frontend/src/app/services/index.ts
+++ b/frontend/src/app/services/index.ts
@@ -1,5 +1,7 @@
+import { NotificationService } from "./notification-service/notification-service.service";
 import { ReceiptApiService } from "./receipt-api/receipt-api.service";
 
 export {
+  NotificationService,
   ReceiptApiService,
 };

--- a/frontend/src/app/services/notification-service/notification-service.service.spec.ts
+++ b/frontend/src/app/services/notification-service/notification-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NotificationServiceService } from './notification-service.service';
+
+describe('NotificationServiceService', () => {
+  let service: NotificationServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/notification-service/notification-service.service.ts
+++ b/frontend/src/app/services/notification-service/notification-service.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { Injectable } from "@angular/core";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { ReceiptError, ReceiptSuccess, SnackbarSeverity } from "src/app/model";
+import { NotificationSnackbarComponent } from "../../components";
 
 @Injectable({
   providedIn: 'root'
@@ -8,10 +10,18 @@ export class NotificationService {
 
   constructor() { }
   
-  public setNotification(snackBar: MatSnackBar, message: string): void {
-    snackBar.open(message, "Close", {
+  public setNotification(
+    snackBar: MatSnackBar, 
+    message: ReceiptError | ReceiptSuccess,
+    severity: SnackbarSeverity = SnackbarSeverity.Error, // defaults to the "error" severity
+  ): void {
+    snackBar.openFromComponent(NotificationSnackbarComponent, {
       verticalPosition: "top",
-      duration: 5000, // the user can cancel the snackbar or it will close on its own after 5 seconds
+      // duration: 5000,
+      data: {
+        message: message,
+        severity: severity,
+      },
     });
   }
 }

--- a/frontend/src/app/services/notification-service/notification-service.service.ts
+++ b/frontend/src/app/services/notification-service/notification-service.service.ts
@@ -8,8 +8,6 @@ import { NotificationSnackbarComponent } from "../../components";
 })
 export class NotificationService {
 
-  constructor() { }
-  
   public setNotification(
     snackBar: MatSnackBar, 
     message: ReceiptError | ReceiptSuccess,
@@ -17,11 +15,12 @@ export class NotificationService {
   ): void {
     snackBar.openFromComponent(NotificationSnackbarComponent, {
       verticalPosition: "top",
-      // duration: 5000,
+      duration: 5000, // if the user doesn't close the snackbar after 5 seconds it will close itself
       data: {
         message: message,
         severity: severity,
       },
     });
   }
+  
 }

--- a/frontend/src/app/services/notification-service/notification-service.service.ts
+++ b/frontend/src/app/services/notification-service/notification-service.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationService {
+
+  constructor() { }
+  
+  public setNotification(snackBar: MatSnackBar, message: string): void {
+    snackBar.open(message, "Close", {
+      verticalPosition: "top",
+      duration: 5000, // the user can cancel the snackbar or it will close on its own after 5 seconds
+    });
+  }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,7 +5,7 @@ html, body {
 }
 
 body {
-  background-color: whitesmoke;
+  /* background-color: whitesmoke; */
   margin: 0; 
   font-family: Roboto, "Helvetica Neue", sans-serif; 
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,7 +5,7 @@ html, body {
 }
 
 body {
-  /* background-color: whitesmoke; */
+  background-color: whitesmoke;
   margin: 0; 
   font-family: Roboto, "Helvetica Neue", sans-serif; 
 }


### PR DESCRIPTION
This PR will add a new service to the frontend that handles displaying a `snackbar` when an error occurs or some operation is successful (uploading a receipt and/or viewing the accrued points for a receipt).

This service will be used in both the `ReceiptForm` and `ReceiptItem` components, I also ended up creating a custom `NotificationSnackbar` component that takes in a message which is either of an instance of the `ReceiptError` or the `ReceiptSuccess` enum that represent the various error or success strings.

Lastly I added a `SnackbarSeverity` enum that holds onto a `error` or `success` CSS class name which changes the notification snackbar styling depending on the type of notification.

This PR addresses issue #9 