### PR TITLE
receipt-api/remove mat snackbar references from components to notification service

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -23,7 +23,7 @@ import {
   ReceiptFormComponent,
   ReceiptItemComponent,
   ReceiptItemListComponent,
-  ViewReceiptPointsComponent
+  ViewReceiptPointsComponent,
 } from "./components/index";
 
 @NgModule({

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -54,7 +54,6 @@ export class ReceiptFormComponent {
         .subscribe(
           (receiptId: ReceiptIdResponse) => {
             this.notificationService.setNotification(
-              this.notificationSnackBar,
               ReceiptSuccess.ReceiptSubmission,
               SnackbarSeverity.Success
             );
@@ -70,7 +69,6 @@ export class ReceiptFormComponent {
           (err) => {
             console.error(`Error posting receipt object -- ${err}`);
             this.notificationService.setNotification(
-              this.notificationSnackBar,
               ReceiptError.ReceiptSubmissionError
             );
           }
@@ -78,7 +76,6 @@ export class ReceiptFormComponent {
       /* eslint-disable @typescript-eslint/no-explicit-any */
     } catch (e: any) {
       this.notificationService.setNotification(
-        this.notificationSnackBar,
         e.message
       );
     }

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -75,9 +75,7 @@ export class ReceiptFormComponent {
         );
       /* eslint-disable @typescript-eslint/no-explicit-any */
     } catch (e: any) {
-      this.notificationService.setNotification(
-        e.message
-      );
+      this.notificationService.setNotification(e.message);
     }
   }
 

--- a/frontend/src/app/components/receipt-item/receipt-item.component.ts
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.ts
@@ -14,7 +14,7 @@ import { NotificationService } from "src/app/services";
 })
 export class ReceiptItemComponent {
   public constructor(
-    private notificationService: NotificationService,
+    private notificationService: NotificationService
   ) {}
 
   // this is used for displaying an already added ReceiptItem

--- a/frontend/src/app/components/receipt-item/receipt-item.component.ts
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.ts
@@ -4,7 +4,6 @@ import {
   Input,
   Output,
 } from "@angular/core";
-import { MatSnackBar } from "@angular/material/snack-bar";
 import { ReceiptError, ReceiptItem } from "src/app/model";
 import { NotificationService } from "src/app/services";
 
@@ -16,7 +15,6 @@ import { NotificationService } from "src/app/services";
 export class ReceiptItemComponent {
   public constructor(
     private notificationService: NotificationService,
-    private notificationSnackBar: MatSnackBar
   ) {}
 
   // this is used for displaying an already added ReceiptItem
@@ -34,12 +32,10 @@ export class ReceiptItemComponent {
   ): void {
     if (!shortDescription) {
       this.notificationService.setNotification(
-        this.notificationSnackBar,
         ReceiptError.MissingItemDescription
       );
     } else if (!price) {
       this.notificationService.setNotification(
-        this.notificationSnackBar,
         ReceiptError.MissingItemPrice
       );
     } else {

--- a/frontend/src/app/services/notification-service/notification-service.service.ts
+++ b/frontend/src/app/services/notification-service/notification-service.service.ts
@@ -11,12 +11,13 @@ import { NotificationSnackbarComponent } from "../../components";
   providedIn: "root",
 })
 export class NotificationService {
+  public constructor(private notificationSnackbar: MatSnackBar) {}
+
   public setNotification(
-    snackBar: MatSnackBar,
     message: ReceiptError | ReceiptSuccess,
     severity: SnackbarSeverity = SnackbarSeverity.Error // defaults to the "error" severity
   ): void {
-    snackBar.openFromComponent(NotificationSnackbarComponent, {
+    this.notificationSnackbar.openFromComponent(NotificationSnackbarComponent, {
       verticalPosition: "top",
       duration: 5000, // if the user doesn't close the snackbar after 5 seconds it will close itself
       data: {

--- a/frontend/src/app/services/notification-service/notification-service.service.ts
+++ b/frontend/src/app/services/notification-service/notification-service.service.ts
@@ -17,13 +17,16 @@ export class NotificationService {
     message: ReceiptError | ReceiptSuccess,
     severity: SnackbarSeverity = SnackbarSeverity.Error // defaults to the "error" severity
   ): void {
-    this.notificationSnackbar.openFromComponent(NotificationSnackbarComponent, {
-      verticalPosition: "top",
-      duration: 5000, // if the user doesn't close the snackbar after 5 seconds it will close itself
-      data: {
-        message: message,
-        severity: severity,
-      },
-    });
+    this.notificationSnackbar.openFromComponent(
+      NotificationSnackbarComponent,
+      {
+        verticalPosition: "top",
+        duration: 5000, // if the user doesn't close the snackbar after 5 seconds it will close itself
+        data: {
+          message: message,
+          severity: severity,
+        },
+      }
+    );
   }
 }


### PR DESCRIPTION
This PR just removes the `MatSnackbar` reference/instance from the `ReceiptForm` and `ReceiptItem` components and adds it to the `NotificationService` via its constructor.

So now instead of have two `MatSnackbar` instances in two components and passing that as an argument to `NotificationService.setNotification` the notification service uses its own instance to open the snackbar.