### PR TITLE
receipt-api/16 allow users to edit receipt item after being added

### DIFF
--- a/backend/src/main/kotlin/com/receipt_api/receipt/MainVerticle.kt
+++ b/backend/src/main/kotlin/com/receipt_api/receipt/MainVerticle.kt
@@ -10,6 +10,9 @@ import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.kotlin.core.json.json
 import io.vertx.kotlin.core.json.obj
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class MainVerticle : AbstractVerticle() {
   private var inMemoryCache: MutableMap<String, Int> = mutableMapOf()
@@ -43,58 +46,77 @@ class MainVerticle : AbstractVerticle() {
     val body = context.getBodyAsJson();
     body ?: run {
       // handle an empty request here
+      serverLog("error reading request body")
       context.response().statusCode = 400
       context.response().putHeader("X-Receipt-Missing-Data", "true")
       context.response().putHeader("Content-Type", "application/json")
       context.json(JsonObject().put("error", "POST body is missing required data"))
-//      context.response().end("{ \"error\": \"POST body is missing required data\" }")
       return
     }
 
     try {
       // create receipt object
-      // this way sucks, i can't import "gson" so i have to do this by hand for now
+      // this approach isn't great, i can't import "gson" so i have to do this by hand for now
       val receipt = ReceiptProcessor.fromJson(body)
 
-      println(receipt) // debugging
+      //println(receipt) // debugging
 
       // process receipt object and store it in memory
       val receiptPoints = ReceiptProcessor.processReceipt(receipt)
       inMemoryCache[receipt.id] = receiptPoints
 
+      serverLog("successfully created and stored receipt, returning receipt id \"${receipt.id}\"")
+
       context.response().statusCode = 200
       context.response().putHeader("Content-Type", "application/json")
       context.json(JsonObject().put("id", receipt.id))
-//      context.response().end("{ \"id\": \"${receipt.id}\" }")
     } catch (e: Error) {
       // handle missing attributes in request here
       val cause = e.cause?.message
       val message = e.message
 
+      serverLog(message ?: cause ?: "missing required attribute types in request body")
+
       context.response().statusCode = 400
       context.response().putHeader("X-Receipt-Missing-Data", cause)
       context.response().putHeader("Content-Type", "application/json")
       context.json(JsonObject().put("error", message))
-//      context.response().end("{ \"error\": \"$message\" }")
     }
   }
 
   private fun getReceiptPointsById(context: RoutingContext) {
     val pathParamId = context.pathParam("id")
 
+    pathParamId ?: run {
+      serverLog("error in GET path -- missing required receipt id")
+      context.response().statusCode = 400
+      context.response().putHeader("X-Missing-Filed", "no path \"ID\"")
+      context.response().putHeader("Content-Type", "application/json")
+      context.json(JsonObject().put("error", "please provide an id in the path"))
+    }
+
     val foundReceipt = inMemoryCache[pathParamId]
     foundReceipt ?: run {
+      serverLog("error fetching receipt points with id \"${pathParamId}\"")
       context.response().statusCode = 404
       context.response().putHeader("X-Receipt-Not-Exist", pathParamId)
       context.response().putHeader("Content-Type", "application/json")
       context.json(JsonObject().put("error", "receipt not found with id"))
-//      context.response().end("{ \"error\": \"receipt not found\" }")
       return
     }
+
+    serverLog("successfully fetched receipt, returning receipt points \"${foundReceipt}\"")
 
     context.response().statusCode = 200
     context.response().putHeader("Content-Type", "application/json")
     context.json(JsonObject().put("points", foundReceipt))
-//    context.response().end("{ \"points\": $foundReceipt }")
+  }
+
+  // NOTE: I'm using index 2 here because that is the previous context prior to this method being called
+  private fun serverLog(message: String) {
+    val serverLogDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS")
+    val serverLogDate = LocalDateTime.now().format(serverLogDateFormat)
+    val loggingFromMethod = Thread.currentThread().stackTrace[2].methodName
+    println("LOG $serverLogDate [ ${loggingFromMethod}: $message ]")
   }
 }

--- a/backend/src/main/kotlin/com/receipt_api/receipt/MainVerticle.kt
+++ b/backend/src/main/kotlin/com/receipt_api/receipt/MainVerticle.kt
@@ -10,7 +10,6 @@ import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.kotlin.core.json.json
 import io.vertx.kotlin.core.json.obj
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -30,7 +30,8 @@
             "prefix": "app",
             "style": "kebab-case"
           }
-        ]
+        ],
+        "@typescript-eslint/no-inferrable-types": "off"
       }
     },
     {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/router": "^15.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
+        "uuidv4": "^6.2.13",
         "zone.js": "~0.12.0"
       },
       "devDependencies": {
@@ -4424,6 +4425,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -13507,9 +13513,17 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -17379,6 +17393,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/ws": {
       "version": "8.5.4",
@@ -24197,8 +24216,16 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "requires": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@angular/router": "^15.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
+    "uuidv4": "^6.2.13",
     "zone.js": "~0.12.0"
   },
   "devDependencies": {

--- a/frontend/src/app/components/receipt-form/receipt-form.component.css
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.css
@@ -11,14 +11,14 @@ mat-card-title {
 }
 
 mat-card-content {
-  width: 25rem;
+  width: 30rem;
 }
 
 mat-form-field {
-  width: 23rem;
+  width: 28rem;
 }
 
 button {
-  width: 22rem;
+  width: 27rem;
   margin-left: 0.65rem;
 }

--- a/frontend/src/app/components/receipt-form/receipt-form.component.html
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.html
@@ -29,12 +29,15 @@
           <br>
 
           <!-- Items -->
-          <app-receipt-item-list (receiptItemsEmitter)="updateReceiptItems($event)"/>
+          <app-receipt-item-list 
+            (receiptItemsEmitter)="updateReceiptItems($event)"
+            (editReceiptItemEmitter)="editReceiptItem($event)"
+          />
 
           <!-- Total -->
           <mat-form-field>
             <mat-label for="total">Total</mat-label>
-            <input disabled id="total" matInput type="number" value="{{ total }}">
+            <input disabled id="total" matInput type="text" value="{{ total }}">
           </mat-form-field>
           <br>
 

--- a/frontend/src/app/components/receipt-form/receipt-form.component.html
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.html
@@ -39,7 +39,10 @@
           <br>
 
           <!-- Submit -->
-          <button mat-raised-button type="submit">Submit</button>
+          <button mat-raised-button type="submit">
+            <mat-icon fontIcon="shopping_cart_checkout"/>
+            Submit
+          </button>
         </form>
       </mat-card-content>
     </mat-card-content>

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -1,6 +1,5 @@
 import { Component } from "@angular/core";
 import { FormControl, FormGroup } from "@angular/forms";
-import { MatSnackBar } from "@angular/material/snack-bar";
 import { MatBottomSheet } from "@angular/material/bottom-sheet";
 import { ViewReceiptPointsComponent } from "../view-receipt-points/view-receipt-points.component";
 import {
@@ -24,25 +23,47 @@ import {
 export class ReceiptFormComponent {
   constructor(
     private viewReceiptPointsSheet: MatBottomSheet,
-    private notificationSnackBar: MatSnackBar,
     private receiptApiService: ReceiptApiService,
     private notificationService: NotificationService
   ) {}
 
   // receipt fields
-  public receiptItems: Array<ReceiptItem> = [];
-  public total = "0.00";
   public receiptForm = new FormGroup({
     retailerName: new FormControl(""),
     purchaseDate: new FormControl(""),
     purchaseTime: new FormControl(""),
   });
+  public receiptItems: Array<ReceiptItem> = [];
+  public total = "$0.00";
 
   // binding between array of ReceiptItem's in child component (ReceiptItemList) and this component
   public updateReceiptItems(receiptItem: ReceiptItem): void {
-    const summedTotal = (+this.total + +receiptItem.price).toString();
-    this.total = parseFloat(summedTotal).toFixed(2);
+    const summedTotal = (+this.formatTotal() + +receiptItem.price).toString();
+    this.total = `\$${parseFloat(summedTotal).toFixed(2)}`;
     this.receiptItems.push(receiptItem);
+  }
+
+  // binding that connects this component to the ReceiptItemListComponent, handles editing of an added ReceiptItem
+  public editReceiptItem(receiptItem: ReceiptItem): void {
+    // verify the ReceiptItem being updated is present in the ReceiptItem array
+    const itemToUpdate = this.receiptItems.find((item) => item.id === receiptItem.id);
+    if (!itemToUpdate) {
+      this.notificationService.setNotification(
+        ReceiptError.ReceiptItemNotFound
+      );
+      return;
+    }
+
+    // change the price if the price has been changed
+    if (itemToUpdate.price !== receiptItem.price) {
+      const subtractedTotal = ((+this.formatTotal() - +itemToUpdate.price)).toString();
+      const newTotal = (+subtractedTotal + +receiptItem.price).toString();
+      this.total = `\$${parseFloat(newTotal).toFixed(2)}`;
+    }
+
+    // update the array of ReceiptItems
+    const itemIndex = this.receiptItems.indexOf(itemToUpdate);
+    this.receiptItems[itemIndex] = receiptItem;
   }
 
   public submitForm(): void {
@@ -104,8 +125,13 @@ export class ReceiptFormComponent {
       purchaseDate: purchaseDate,
       purchaseTime: purchaseTime,
       items: this.receiptItems,
-      total: this.total,
+      total: this.formatTotal(),
     };
     return receipt;
+  }
+
+  // this removes the "$" in front of the total
+  private formatTotal(): string {
+    return this.total.substring(1);
   }
 }

--- a/frontend/src/app/components/receipt-form/receipt-form.component.ts
+++ b/frontend/src/app/components/receipt-form/receipt-form.component.ts
@@ -38,15 +38,19 @@ export class ReceiptFormComponent {
 
   // binding between array of ReceiptItem's in child component (ReceiptItemList) and this component
   public updateReceiptItems(receiptItem: ReceiptItem): void {
-    const summedTotal = (+this.formatTotal() + +receiptItem.price).toString();
-    this.total = `\$${parseFloat(summedTotal).toFixed(2)}`;
+    const summedTotal = (
+      +this.formatTotal() + +receiptItem.price
+    ).toString();
+    this.total = `$${parseFloat(summedTotal).toFixed(2)}`;
     this.receiptItems.push(receiptItem);
   }
 
   // binding that connects this component to the ReceiptItemListComponent, handles editing of an added ReceiptItem
   public editReceiptItem(receiptItem: ReceiptItem): void {
     // verify the ReceiptItem being updated is present in the ReceiptItem array
-    const itemToUpdate = this.receiptItems.find((item) => item.id === receiptItem.id);
+    const itemToUpdate = this.receiptItems.find(
+      (item) => item.id === receiptItem.id
+    );
     if (!itemToUpdate) {
       this.notificationService.setNotification(
         ReceiptError.ReceiptItemNotFound
@@ -56,9 +60,13 @@ export class ReceiptFormComponent {
 
     // change the price if the price has been changed
     if (itemToUpdate.price !== receiptItem.price) {
-      const subtractedTotal = ((+this.formatTotal() - +itemToUpdate.price)).toString();
-      const newTotal = (+subtractedTotal + +receiptItem.price).toString();
-      this.total = `\$${parseFloat(newTotal).toFixed(2)}`;
+      const subtractedTotal = (
+        +this.formatTotal() - +itemToUpdate.price
+      ).toString();
+      const newTotal = (
+        +subtractedTotal + +receiptItem.price
+      ).toString();
+      this.total = `$${parseFloat(newTotal).toFixed(2)}`;
     }
 
     // update the array of ReceiptItems

--- a/frontend/src/app/components/receipt-item-list/receipt-item-list.component.css
+++ b/frontend/src/app/components/receipt-item-list/receipt-item-list.component.css
@@ -1,4 +1,4 @@
 mat-divider {
   margin-left: -1rem;
-  width: 24.85rem;
+  width: 30rem;
 }

--- a/frontend/src/app/components/receipt-item-list/receipt-item-list.component.html
+++ b/frontend/src/app/components/receipt-item-list/receipt-item-list.component.html
@@ -2,7 +2,10 @@
 
 <!-- Listing the previously added ReceiptItem's -->
 <div *ngFor="let item of receiptItems; index as i">
-  <app-receipt-item [receiptItem]="item"/>
+  <app-receipt-item
+    [receiptItem]="item"
+    (editReceiptItemEmitter)="editReceiptItem($event)"
+  />
 </div>
 
 <!-- ReceiptItem template, this is where you can add a new ReceiptItem -->

--- a/frontend/src/app/components/receipt-item-list/receipt-item-list.component.ts
+++ b/frontend/src/app/components/receipt-item-list/receipt-item-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Output } from "@angular/core";
-import { ReceiptItem } from "src/app/model";
+import { ReceiptItem } from "../../model";
 
 @Component({
   selector: "app-receipt-item-list",
@@ -12,12 +12,20 @@ export class ReceiptItemListComponent {
   @Output()
   public receiptItemsEmitter = new EventEmitter<ReceiptItem>();
 
+  // this is not great, having two seperate emitters, one for adding a new ReceiptItem and this one for editing a single ReceiptItem
+  @Output()
+  public editReceiptItemEmitter = new EventEmitter<ReceiptItem>();
+
   // used to display the list of ReceiptItem's to the user
   public receiptItems: Array<ReceiptItem> = [];
 
   // binding between single added ReceiptItem from child component (ReceiptItemComponent) and this component
-  public addNewReceiptItem(receiptItem: ReceiptItem) {
+  public addNewReceiptItem(receiptItem: ReceiptItem): void {
     this.receiptItems.push(receiptItem);
     this.receiptItemsEmitter.emit(receiptItem);
+  }
+
+  public editReceiptItem(receiptItem: ReceiptItem): void {
+    this.editReceiptItemEmitter.emit(receiptItem);
   }
 }

--- a/frontend/src/app/components/receipt-item/receipt-item.component.css
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.css
@@ -2,6 +2,14 @@ mat-form-field {
   width: 12rem;
 }
 
+.added-item-style {
+  width: 12rem;
+}
+
+.template-style {
+  width: 13.8rem;
+}
+
 .edit-button {
   margin-bottom: 1rem;
   margin-left: 0.5rem;
@@ -9,11 +17,11 @@ mat-form-field {
 
 .submit-button {
   width: 27rem;
-  margin-left: 0.65rem;
+  margin-left: 0.5rem;
 }
 
 mat-divider {
   margin-bottom: 1rem;
   margin-left: 0.5rem;
-  width: 22rem;
+  width: 26.75rem;
 }

--- a/frontend/src/app/components/receipt-item/receipt-item.component.css
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.css
@@ -20,6 +20,14 @@ mat-form-field {
   margin-left: 0.5rem;
 }
 
+.receipt-item-title {
+  font-weight: bold;
+  text-align: center;
+
+  /* this is a hack, realistically i need to address why the items in this div are off-centered to the right instead of compensating with a negative left margin */
+  margin-left: -2rem;
+}
+
 mat-divider {
   margin-bottom: 1rem;
   margin-left: 0.5rem;

--- a/frontend/src/app/components/receipt-item/receipt-item.component.css
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.css
@@ -1,9 +1,9 @@
 mat-form-field {
-  width: 11.5rem;
+  width: 12rem;
 }
 
 button {
-  width: 22rem;
+  width: 27rem;
   margin-left: 0.65rem;
 }
 

--- a/frontend/src/app/components/receipt-item/receipt-item.component.css
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.css
@@ -2,7 +2,12 @@ mat-form-field {
   width: 12rem;
 }
 
-button {
+.edit-button {
+  margin-bottom: 1rem;
+  margin-left: 0.5rem;
+}
+
+.submit-button {
   width: 27rem;
   margin-left: 0.65rem;
 }

--- a/frontend/src/app/components/receipt-item/receipt-item.component.html
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.html
@@ -37,6 +37,10 @@
         >
       </mat-form-field>
     </td>
+    <td>
+      <!-- Receipt item edit toggle button -->
+      
+    </td>
   </tr>
 </table>
 <div *ngIf="!receiptItem">

--- a/frontend/src/app/components/receipt-item/receipt-item.component.html
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.html
@@ -1,7 +1,7 @@
 <!-- Receipt item title -->
-<span style="margin-left: 9.75rem; font-weight: bold;">
+<div class="receipt-item-title">
   {{ receiptItem?.shortDescription || "Add Item" }}
-</span>
+</div>
 
 <table style="margin-top: 1rem;" cellspacing="0">
   <tr>
@@ -12,7 +12,7 @@
           Short Description
         </mat-label>
         <input
-          [disabled]="editingReceiptItem"
+          [disabled]="!isEditing"
           id="short-description" 
           matInput 
           type="text"
@@ -28,7 +28,7 @@
           Price
         </mat-label>
         <input
-          [disabled]="editingReceiptItem"
+          [disabled]="!isEditing"
           id="price" 
           matInput 
           type="number" 
@@ -44,7 +44,7 @@
         class="edit-button"
         type="button"
         mat-icon-button
-        (click)="editReceiptItem()"
+        (click)="editReceiptItem(shortDescription.value, price.value)"
       >
         <mat-icon fontIcon="edit"/>
       </button>
@@ -52,14 +52,15 @@
   </tr>
 </table>
 <div *ngIf="!receiptItem">
+  <!-- Receipt item add button -->
   <!-- Button displayed only if this element is the template one -->
-  <!-- NOTE: Add "+" icon to this button if possible to make it look nice -->
   <button
     class="submit-button"
     type="button"
     mat-raised-button
     (click)="addReceiptItem(shortDescription.value, price.value)"
   >
+    <mat-icon fontIcon="add"/>
     Add Item
   </button>
 </div>

--- a/frontend/src/app/components/receipt-item/receipt-item.component.html
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.html
@@ -7,12 +7,12 @@
   <tr>
     <td>
       <!-- Receipt item short description -->
-      <mat-form-field>
+      <mat-form-field class="{{ inputFieldStyles }}">
         <mat-label for="short-description">
           Short Description
         </mat-label>
         <input
-          disabled="{{ receiptItem !== undefined }}"
+          [disabled]="editingReceiptItem"
           id="short-description" 
           matInput 
           type="text"
@@ -23,12 +23,12 @@
     </td>
     <td style="padding-left: 0.25rem;">
       <!-- Receipt item price -->
-      <mat-form-field>
+      <mat-form-field class="{{ inputFieldStyles }}">
         <mat-label for="price">
           Price
         </mat-label>
         <input
-          disabled="{{ receiptItem !== undefined }}"
+          [disabled]="editingReceiptItem"
           id="price" 
           matInput 
           type="number" 
@@ -37,11 +37,14 @@
         >
       </mat-form-field>
     </td>
-    <td>
-      <!-- Receipt item edit toggle button -->
+    <!-- Receipt item edit toggle button -->
+    <!-- This should only be displayed for ReceiptItems that have previously been added, not the template ReceiptItem -->
+    <td *ngIf="receiptItem">
       <button
         class="edit-button"
+        type="button"
         mat-icon-button
+        (click)="editReceiptItem()"
       >
         <mat-icon fontIcon="edit"/>
       </button>

--- a/frontend/src/app/components/receipt-item/receipt-item.component.html
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.html
@@ -21,7 +21,7 @@
         >
       </mat-form-field>
     </td>
-    <td>
+    <td style="padding-left: 0.25rem;">
       <!-- Receipt item price -->
       <mat-form-field>
         <mat-label for="price">
@@ -39,7 +39,12 @@
     </td>
     <td>
       <!-- Receipt item edit toggle button -->
-      
+      <button
+        class="edit-button"
+        mat-icon-button
+      >
+        <mat-icon fontIcon="edit"/>
+      </button>
     </td>
   </tr>
 </table>
@@ -47,6 +52,7 @@
   <!-- Button displayed only if this element is the template one -->
   <!-- NOTE: Add "+" icon to this button if possible to make it look nice -->
   <button
+    class="submit-button"
     type="button"
     mat-raised-button
     (click)="addReceiptItem(shortDescription.value, price.value)"

--- a/frontend/src/app/components/receipt-item/receipt-item.component.ts
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.ts
@@ -1,12 +1,11 @@
 import {
   Component,
   EventEmitter,
-  Inject,
   Input,
   OnInit,
   Output,
 } from "@angular/core";
-import { Observable, of } from "rxjs";
+import { v4 as uuid } from 'uuid';
 import { ReceiptError, ReceiptItem } from "src/app/model";
 import { NotificationService } from "src/app/services";
 
@@ -24,9 +23,10 @@ export class ReceiptItemComponent implements OnInit {
     // decide which styling is needed based on if this ReceiptItem component is displaying an added item or the template
     this.inputFieldStyles = this.receiptItem ? "added-item-style" : "template-style";
 
-    // set the boolean observable attribute that keeps track of whether or not the added receipt item is being edited
-    // this.editingReceiptItem = of(!!this.receiptItem); // originally using an observable here
-    this.editingReceiptItem = !!this.receiptItem;
+    // this is bad logic, it works but i have a double negative i think which makes this hard to read
+    // in the html the two input fields disabled state is set to the opposite of this.isEditing
+    // so if this.isEditing === false then the fields are disabled, if this.isEditing === true then the fields are not disabled
+    this.isEditing = this.receiptItem ? false : true;
   }
 
   // this is used for displaying an already added ReceiptItem
@@ -37,10 +37,13 @@ export class ReceiptItemComponent implements OnInit {
   // this emits when a new ReceiptItem is created/add
   @Output()
   public receiptItemEmitter = new EventEmitter<ReceiptItem>();
+
+  @Output()
+  public editReceiptItemEmitter = new EventEmitter<ReceiptItem>();
   
   // keeps track of a ReceiptItem and if it is being edited or not
   // public editingReceiptItem: Observable<boolean> = new Observable<boolean>(); // originally using an observable here
-  public editingReceiptItem: boolean = false;
+  public isEditing: boolean = true;
 
   // keeps track of the styling needed on the input fields
   public inputFieldStyles: string = "";
@@ -60,14 +63,38 @@ export class ReceiptItemComponent implements OnInit {
     } else {
       // emites the newly created ReceiptItem to the parent component "ReceiptItemList"
       this.receiptItemEmitter.emit({
+        id: uuid(),
         shortDescription: shortDescription,
         price: price,
       });
     }
   }
 
-  public editReceiptItem(): void {
-    // this.editingReceiptItem = of(!this.editingReceiptItem); // originally using an observable here
-    this.editingReceiptItem = !this.editingReceiptItem;
+  public editReceiptItem(
+    shortDescription: string,
+    price: string
+  ): void {
+    if (!this.receiptItem || !shortDescription || !price) {
+      this.notificationService.setNotification(
+        ReceiptError.EditReceiptItemError,
+      );
+      return;
+    }
+
+    const hasBeenEdited = 
+      this.receiptItem.shortDescription !== shortDescription || 
+      this.receiptItem.price !== price;
+
+    // if edits were made then we want to emit those changes up
+    if (this.isEditing && hasBeenEdited) {
+      this.receiptItem = {
+        id: this.receiptItem.id,
+        shortDescription: shortDescription,
+        price: price,
+      };
+      this.editReceiptItemEmitter.emit(this.receiptItem);
+    }
+
+    this.isEditing = !this.isEditing;
   }
 }

--- a/frontend/src/app/components/receipt-item/receipt-item.component.ts
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit,
   Output,
 } from "@angular/core";
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid } from "uuid";
 import { ReceiptError, ReceiptItem } from "src/app/model";
 import { NotificationService } from "src/app/services";
 
@@ -21,7 +21,9 @@ export class ReceiptItemComponent implements OnInit {
 
   public ngOnInit(): void {
     // decide which styling is needed based on if this ReceiptItem component is displaying an added item or the template
-    this.inputFieldStyles = this.receiptItem ? "added-item-style" : "template-style";
+    this.inputFieldStyles = this.receiptItem
+      ? "added-item-style"
+      : "template-style";
 
     // this is bad logic, it works but i have a double negative i think which makes this hard to read
     // in the html the two input fields disabled state is set to the opposite of this.isEditing
@@ -40,7 +42,7 @@ export class ReceiptItemComponent implements OnInit {
 
   @Output()
   public editReceiptItemEmitter = new EventEmitter<ReceiptItem>();
-  
+
   // keeps track of a ReceiptItem and if it is being edited or not
   // public editingReceiptItem: Observable<boolean> = new Observable<boolean>(); // originally using an observable here
   public isEditing: boolean = true;
@@ -76,13 +78,13 @@ export class ReceiptItemComponent implements OnInit {
   ): void {
     if (!this.receiptItem || !shortDescription || !price) {
       this.notificationService.setNotification(
-        ReceiptError.EditReceiptItemError,
+        ReceiptError.EditReceiptItemError
       );
       return;
     }
 
-    const hasBeenEdited = 
-      this.receiptItem.shortDescription !== shortDescription || 
+    const hasBeenEdited =
+      this.receiptItem.shortDescription !== shortDescription ||
       this.receiptItem.price !== price;
 
     // if edits were made then we want to emit those changes up

--- a/frontend/src/app/components/receipt-item/receipt-item.component.ts
+++ b/frontend/src/app/components/receipt-item/receipt-item.component.ts
@@ -1,9 +1,12 @@
 import {
   Component,
   EventEmitter,
+  Inject,
   Input,
+  OnInit,
   Output,
 } from "@angular/core";
+import { Observable, of } from "rxjs";
 import { ReceiptError, ReceiptItem } from "src/app/model";
 import { NotificationService } from "src/app/services";
 
@@ -12,10 +15,19 @@ import { NotificationService } from "src/app/services";
   templateUrl: "./receipt-item.component.html",
   styleUrls: ["./receipt-item.component.css"],
 })
-export class ReceiptItemComponent {
+export class ReceiptItemComponent implements OnInit {
   public constructor(
     private notificationService: NotificationService
   ) {}
+
+  public ngOnInit(): void {
+    // decide which styling is needed based on if this ReceiptItem component is displaying an added item or the template
+    this.inputFieldStyles = this.receiptItem ? "added-item-style" : "template-style";
+
+    // set the boolean observable attribute that keeps track of whether or not the added receipt item is being edited
+    // this.editingReceiptItem = of(!!this.receiptItem); // originally using an observable here
+    this.editingReceiptItem = !!this.receiptItem;
+  }
 
   // this is used for displaying an already added ReceiptItem
   @Input()
@@ -25,6 +37,13 @@ export class ReceiptItemComponent {
   // this emits when a new ReceiptItem is created/add
   @Output()
   public receiptItemEmitter = new EventEmitter<ReceiptItem>();
+  
+  // keeps track of a ReceiptItem and if it is being edited or not
+  // public editingReceiptItem: Observable<boolean> = new Observable<boolean>(); // originally using an observable here
+  public editingReceiptItem: boolean = false;
+
+  // keeps track of the styling needed on the input fields
+  public inputFieldStyles: string = "";
 
   public addReceiptItem(
     shortDescription: string,
@@ -45,5 +64,10 @@ export class ReceiptItemComponent {
         price: price,
       });
     }
+  }
+
+  public editReceiptItem(): void {
+    // this.editingReceiptItem = of(!this.editingReceiptItem); // originally using an observable here
+    this.editingReceiptItem = !this.editingReceiptItem;
   }
 }

--- a/frontend/src/app/model/receipt.ts
+++ b/frontend/src/app/model/receipt.ts
@@ -7,6 +7,7 @@ type ReceiptIdResponse = {
 };
 
 type ReceiptItem = {
+  id: string;
   shortDescription: string;
   price: string;
 };

--- a/frontend/src/app/model/snackbar-data.ts
+++ b/frontend/src/app/model/snackbar-data.ts
@@ -16,6 +16,8 @@ enum ReceiptError {
   MissingItemDescription = "Please enter a short description of the receipt item",
   MissingItemPrice = "Please enter a price for the receipt item",
   ReceiptSubmissionError = "There was an error submitting the receipt",
+  EditReceiptItemError = "When editing an item the item must have a description and price",
+  ReceiptItemNotFound = "You are attempting to edit a receipt item that doesn't exist",
   // NOTE: when adding new possible error messages for the MatSnackBar add them here
 }
 


### PR DESCRIPTION
This PR adds the ability to edit previously added `ReceiptItem`'s -- a new _edit_ icon button is present next to the input fields of an added receipt item. Clicking this edit button will re-enable the two input fields for said receipt item allowing the user to change what they had submitted previously. Clicking the _edit button_ again will disable the text fields and change the receipt item so it will be processed with the correct data.

Prior to this PR you couldn't edit added `ReceiptItems` meaning if you had a typo in the added receipt item you would need to refresh the page to fix it which meant all previously entered data for the `Receipt` would be lost.

**Note:** Currently this PR is still a **WIP**, will remove this note before merging this PR in after completing the issue.

This PR addresses issue #16 